### PR TITLE
Fix package.browser field; add peer dependency on racer

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -1,7 +1,10 @@
 const racer = require('racer')
 const Socket = require('./socket')
-const CLIENT_OPTIONS = JSON.parse('{{clientOptions}}')
+// need another way to set options for Socket
+// channel: literally the default in this package
+const CLIENT_OPTIONS = { base: '/channel' };
 
-racer.Model.prototype._createSocket = function (bundle) {
+// why does this function accept data param?
+racer.Model.prototype._createSocket = function (appdata) {
   return new Socket(CLIENT_OPTIONS)
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "description": "Websocket and browserchannel transport for Racer",
   "version": "10.0.1",
   "main": "./lib/server",
-  "browser": {
-    "main": "./lib/browser"
-  },
+  "browser": "./lib/browser",
   "dependencies": {
     "extend": "^2.0.0",
     "through": "^2.3.4",
     "ws": "^1.1.5"
+  },
+  "peerDependencies": {
+    "racer": "^0.9.0"
   },
   "devDependencies": {
     "standard": "^16.0.4"


### PR DESCRIPTION
`racer-highway` has implicit dependency on browserify processing for injecting into a Derby app bundle and transforming string placeholder for configuration (similar to `racer-browserchannel`) This is an attempt to remove this coupling so other package bundlers e.g. `webpack` can be used. 

- update `package.broswer` field to string path pointing to browser entry point that webpack uses for browser bundle
- add `package.peerDependency` for `racer`

## TODO
- [ ] provide another method for providing configuration